### PR TITLE
Add units for short forms and 'Murrica

### DIFF
--- a/lib/quantified/length.rb
+++ b/lib/quantified/length.rb
@@ -2,18 +2,34 @@ module Quantified
   class Length < Attribute
     system :metric do
       primitive :metre
+      one :meter, :is => Length.new(1, :metres)
+      one :m, :plural => :m, :is => Length.new(1, :metres)
 
       one :centimetre, :is => Length.new(0.01, :metres)
+      one :centimeter, :is => Length.new(0.01, :metres)
+      one :cm, :plural => :cm, :is => Length.new(0.01, :metres)
+
       one :millimetre, :is => Length.new(0.1, :centimetres)
+      one :millimeter, :is => Length.new(0.1, :centimetres)
+      one :mm, :plural => :mm, :is => Length.new(0.1, :centimetres)
+
       one :kilometre, :is => Length.new(1000, :metres)
+      one :kilometer, :is => Length.new(1000, :metres)
+      one :km, :plural => :km, :is => Length.new(1000, :metres)
     end
 
     system :imperial do
       primitive :inch
+
       one :inch, :is => Length.new(0.0254, :metres)
+      one :in, :plural => :in, :is => Length.new(0.0254, :metres)
 
       one :foot, :plural => :feet, :is => Length.new(12, :inches)
+      one :ft, :plural => :ft, :is => Length.new(12, :inches)
+
       one :yard, :is => Length.new(3, :feet)
+      one :yd, :plural => :yd, :is => Length.new(3, :feet)
+
       one :mile, :is => Length.new(5280, :feet)
     end
   end

--- a/lib/quantified/mass.rb
+++ b/lib/quantified/mass.rb
@@ -2,17 +2,29 @@ module Quantified
   class Mass < Attribute
     system :metric do
       primitive :gram
+      one :g, :plural => :g, :is => Mass.new(1, :grams)
 
       one :milligram, :is => Mass.new(0.001, :grams)
+      one :mg, :plural => :mg, :is => Mass.new(0.001, :grams)
+
+      one :carat, :is => Mass.new(0.2, :grams)
+      one :ct, :plural => :ct, :is => Mass.new(0.2, :grams)
+
       one :kilogram, :is => Mass.new(1000, :grams)
+      one :kg, :plural => :kg, :is => Mass.new(1000, :grams)
     end
 
     system :imperial do
       primitive :ounce
       one :ounce, :is => Mass.new(28.349523125, :grams)
+      one :oz, :plural => :oz, :is => Mass.new(28.349523125, :grams)
 
       one :pound, :is => Mass.new(16, :ounces)
+      one :lb, :plural => :lb, :is => Mass.new(16, :ounces)
+
       one :stone, :is => Mass.new(14, :pounds)
+      one :st, :plural => :st, :is => Mass.new(14, :pounds)
+
       one :short_ton, :is => Mass.new(2000, :pounds)
     end
   end

--- a/lib/quantified/version.rb
+++ b/lib/quantified/version.rb
@@ -1,3 +1,3 @@
 module Quantified
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/length_test.rb
+++ b/test/length_test.rb
@@ -85,8 +85,8 @@ class LengthTest < Test::Unit::TestCase
 
   def test_systems
     assert_equal [:metric, :imperial], Length.systems
-    assert_equal [:metres, :centimetres, :millimetres, :kilometres], Length.units(:metric)
-    assert_equal [:inches, :feet, :yards, :miles], Length.units(:imperial)
+    assert_equal [:metres, :meters, :m, :centimetres, :centimeters, :cm, :millimetres, :millimeters, :mm, :kilometres, :kilometers, :km], Length.units(:metric)
+    assert_equal [:inches, :in, :feet, :ft, :yards, :yd, :miles], Length.units(:imperial)
 
     assert_equal :metric, 2.centimetres.system
     assert_equal :imperial, 2.feet.system

--- a/test/mass_test.rb
+++ b/test/mass_test.rb
@@ -82,8 +82,8 @@ class MassTest < Test::Unit::TestCase
 
   def test_systems
     assert_equal [:metric, :imperial], Mass.systems
-    assert_equal [:grams, :milligrams, :kilograms], Mass.units(:metric)
-    assert_equal [:ounces, :pounds, :stones, :short_tons], Mass.units(:imperial)
+    assert_equal [:grams, :g, :milligrams, :mg, :carats, :ct, :kilograms, :kg], Mass.units(:metric)
+    assert_equal [:ounces, :oz, :pounds, :lb, :stones, :st, :short_tons], Mass.units(:imperial)
   end
 
   def test_right_side_comparison_with_fixnum


### PR DESCRIPTION
Adding some more units for both length and mass that are short-forms as well as American spellings of the current units already present

**Why is this being proposed?**
Passing in ```:mm``` instead of ```:millimetres``` while converting between units is currently not possible. 



cc @wvanbergen for review