### PR TITLE
In gemspec require_path should be require_paths

### DIFF
--- a/quantified.gemspec
+++ b/quantified.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split($/)
   s.executables  = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   s.test_files   = s.files.grep(%r{^(test|spec|features)/})
-  s.require_path = ['lib']
+  s.require_paths = ['lib']
 end


### PR DESCRIPTION
Reference: http://guides.rubygems.org/specification-reference/#require_paths=