### PR TITLE
Add Coder for custom ActiveRecord serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ You can easily define new attributes. Here's length.rb:
         end
       end
     end
+
+You can add a custom coder to an ActiveRecord model to deserialize attributes:
+
+    class Package < ActiveRecord::Base
+      serialize :weight, Quantified::Mass.ounces
+      serialize :length, Quantified::Length.inches
+      serialize :width, Quantified::Length.inches
+    end

--- a/lib/quantified.rb
+++ b/lib/quantified.rb
@@ -1,4 +1,5 @@
 require 'quantified/version'
+require 'quantified/coder'
 require 'quantified/attribute'
 require 'quantified/mass'
 require 'quantified/length'

--- a/lib/quantified/attribute.rb
+++ b/lib/quantified/attribute.rb
@@ -102,6 +102,10 @@ module Quantified
       end
     end
 
+    def self.coder(unit)
+      Coder.new(self, unit)
+    end
+
     protected
 
     class << self
@@ -178,6 +182,7 @@ module Quantified
 
     def self.add_methods_for(sym, options = {})
       add_conversion_method_for(sym, options)
+      add_coder_method_for(sym, options)
       add_numeric_method = if options.has_key?(:add_numeric_methods)
         options[:add_numeric_methods]
       else
@@ -194,6 +199,14 @@ module Quantified
           self.class.new(self.class.convert(amount, unit, unit_name), unit_name)
         end
         alias_method("in_#{unit_name}", "to_#{unit_name}")
+      end
+    end
+
+    def self.add_coder_method_for(sym, options = {})
+      (class << self; self; end).instance_eval do
+        define_method(sym) do
+          Coder.new(self, sym)
+        end
       end
     end
 

--- a/lib/quantified/coder.rb
+++ b/lib/quantified/coder.rb
@@ -12,8 +12,9 @@ module Quantified
     end
 
     def dump(quantity)
-      if quantity.is_a?(attribute)
-        quantity.send("to_#{unit}")
+      conversion = "to_#{unit}"
+      if quantity.respond_to?(conversion)
+        quantity.send(conversion)
       else
         quantity
       end

--- a/lib/quantified/coder.rb
+++ b/lib/quantified/coder.rb
@@ -1,0 +1,22 @@
+module Quantified
+  class Coder
+    attr_reader :attribute, :unit
+
+    def initialize(attribute, unit)
+      @attribute = attribute
+      @unit = unit
+    end
+
+    def load(amount)
+      attribute.new(amount, unit) unless amount.nil?
+    end
+
+    def dump(quantity)
+      if quantity.is_a?(attribute)
+        quantity.send("to_#{unit}")
+      else
+        quantity
+      end
+    end
+  end
+end

--- a/test/coder_test.rb
+++ b/test/coder_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'quantified'
+
+class CoderTest < Test::Unit::TestCase
+  include Quantified
+
+  def setup
+    @coder = Coder.new(Length, :meters)
+  end
+
+  def test_load_nil
+    assert @coder.load(nil).nil?
+  end
+
+  def test_load_numeric
+    assert_equal @coder.load(5), Length.new(5, :meters)
+  end
+
+  def test_dump_nil
+    assert @coder.dump(nil).nil?
+  end
+
+  def test_dump_conversion
+    assert_equal @coder.dump(Length.new(500, :centimeters)), 5
+  end
+end

--- a/test/coder_test.rb
+++ b/test/coder_test.rb
@@ -23,4 +23,8 @@ class CoderTest < Test::Unit::TestCase
   def test_dump_conversion
     assert_equal @coder.dump(Length.new(500, :centimeters)), 5
   end
+
+  def test_dump_numeric
+    assert_equal @coder.dump(5), 5
+  end
 end

--- a/test/length_test.rb
+++ b/test/length_test.rb
@@ -91,4 +91,9 @@ class LengthTest < Test::Unit::TestCase
     assert_equal :metric, 2.centimetres.system
     assert_equal :imperial, 2.feet.system
   end
+
+  def test_coder
+    assert_equal :centimetres, Length.centimetres.unit
+    assert_equal Length, Length.centimetres.attribute
+  end
 end

--- a/test/mass_test.rb
+++ b/test/mass_test.rb
@@ -86,6 +86,11 @@ class MassTest < Test::Unit::TestCase
     assert_equal [:ounces, :oz, :pounds, :lb, :stones, :st, :short_tons], Mass.units(:imperial)
   end
 
+  def test_coder
+    assert_equal :grams, Mass.grams.unit
+    assert_equal Mass, Mass.grams.attribute
+  end
+
   def test_right_side_comparison_with_fixnum
     assert Mass.new(14, :grams) < 20
   end


### PR DESCRIPTION
Add support for a custom coder strategy for encoding ActiveRecord attributes. This lets you apply units to a numeric column like so:

```ruby
class Package < ActiveRecord::Base
  serialize :weight, Quantified::Mass.kilograms
end

Package.create!(weight: 1.pounds).weight
=> #<Quantified::Mass: 0.45359237 kilograms>
```